### PR TITLE
#43 Replace height with min-height for body element to avoid content …

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -27,7 +27,7 @@ $beefinder-theme: mat-light-theme($beefinder-primary, $beefinder-accent, $beefin
 @include angular-material-theme($beefinder-theme);
 
 /* You can add global styles to this file, and also import other style files */
-html, body { 
+html {
   height: 100%; 
 }
 
@@ -35,6 +35,7 @@ body {
   margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif;
   display: flex;
   flex-direction: column;
+  min-height: 100%;
 }
 
 body > * {


### PR DESCRIPTION
…overlapping body element in Safari, iOS

Bisher getestet auf:
- iPhone 6s, iOS 12.2:
-- Safari 604.1
-- Chrome 74.0.3729.121
-- Firefox 16.2 (14898)