### PR TITLE
Isolate functions type definitions to avoid collisions during deployment

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -7,7 +7,10 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
Damit sollte das 'duplicate identifier' Problem im aktuellen Build behoben werden.
Getestet mit: $ npm run --prefix functions build