### PR TITLE
Fixes/messaging token infinity loop

### DIFF
--- a/src/app/views/user/dashboard-user/dashboard-user.component.ts
+++ b/src/app/views/user/dashboard-user/dashboard-user.component.ts
@@ -1,12 +1,9 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
 import {AngularFireMessaging} from '@angular/fire/messaging';
 import {AuthService} from '../../../common/services/auth.service';
 import {Component, OnInit} from '@angular/core';
-import {filter, first, take} from 'rxjs/operators';
-import {
-  InjectableBeekeeperService,
-  InjectableMessagingService
-} from '../../../common/services/injectable-services.service';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import {filter, take} from 'rxjs/operators';
+import {InjectableBeekeeperService, InjectableMessagingService} from '../../../common/services/injectable-services.service';
 import {Router} from '@angular/router';
 
 


### PR DESCRIPTION
Der Fix sollte die Endlosschleife beheben, die entsteht, wenn ein Benutzer sich mit demselben Account in mehreren Browsern oder mehreren Geräten gleichzeitig einloggt und damit unterschiedliche message-tokens generiert werden, die sich immer wieder gegenseitig überschreiben, da das Observable immer wieder die Updates der DB liefert. 
Mir ist unbekannt, ob sich ein individuelles, selbst ausgewähltes messaging-token setzen lässt, sodass auf allen Geräten das gleiche Token gesetzt werden könnte. 